### PR TITLE
bug(#27): relax head/tail so a tail may begin with an application

### DIFF
--- a/sections/foundations.tex
+++ b/sections/foundations.tex
@@ -155,15 +155,19 @@ A \textbf{dispatch}, denoted as $ e . \tau $, where \(e\) is the \enquote{subjec
   means an attempt to retrieve what is attached to \(\tau\) in the formation to which \(e\) may be transformed.
 \end{definition}
 
-\begin{definition}
+\begin{definition}[Head and Tail]
 Since any expression may recursively be defined as \begin{inparaenum}[1)]
     \item $T$,
-    \item formation,
-    \item application,
+    \item a formation,
+    \item an application,
     or
-    \item dispatch,
+    \item a dispatch,
 \end{inparaenum}
-it consists of a \textbf{head} and a possibly empty \textbf{tail}, denoted together as \(h\bullet{}t\).
+it may be split into a \textbf{head} \(h\) and a possibly empty \textbf{tail} \(t\),
+  denoted together as \(h\bullet{}t\),
+  where \(t\) is the ordered sequence of dispatches and applications that,
+  attached to \(h\), reconstructs the expression.
+A tail may begin with either a dispatch or an application, and the split is not unique.
 \end{definition}
 
 \begin{example}
@@ -172,13 +176,17 @@ it consists of a \textbf{head} and a possibly empty \textbf{tail}, denoted toget
 \begin{table*}
 \capt{A few examples that demonstrate the separation between a head and a possibly empty tail of an expression.}
 \label{tab:head-and-tail}
+\adjustbox{max width=\linewidth}{%
 \begin{tabular}{lll}
 \toprule
 Expression & Head & Tail \\
 \midrule
-$b_1( foo -> b_2 )$
-  & $b_1( foo -> b_2 )$
+$b_1$
+  & $b_1$
   & --- \\
+$b_1( foo -> b_2 )$
+  & $b_1$
+  & $( foo -> b_2 )$ \\
 $b_1.|aa|.|bb|( ~0 -> b_2 )$
   & $b_1$
   & $aa.bb( ~0 -> b_2 )$ \\
@@ -186,10 +194,10 @@ $[[ |a| -> b_2 ]].|aa|.|test|.|bb|$
   & $[[ |a| -> b_2 ]]$
   & $aa.test.bb$ \\
 $b_1( |foo| -> b_2)( ~0 -> 42 ).|print|( ~1 -> 7 )$
-  & $b_1( |foo| -> b_2)( ~0 -> 42 )$
-  & $|print|( ~1 -> 7 )$ \\
+  & $b_1$
+  & $( |foo| -> b_2)( ~0 -> 42 ).|print|( ~1 -> 7 )$ \\
 \bottomrule
-\end{tabular}
+\end{tabular}}
 \end{table*}
 \end{example}
 

--- a/zip-it.sh
+++ b/zip-it.sh
@@ -17,9 +17,8 @@ cp -R ../examples .
 mkdir bibliography
 cp ../bibliography/main.bib bibliography/main.bib
 
-TLROOT=$(kpsewhich -var-value TEXMFDIST)
 for p in ffcode to-be-determined href-ul iexec eolang naive-ebnf; do
-    cp "${TLROOT}/tex/latex/${p}/${p}.sty" .
+    cp "$(kpsewhich "${p}.sty")" .
 done
 for d in _tex sections examples; do
     cp -r "../${d}" .


### PR DESCRIPTION
## What and why

Closes #27.

### 1. Relax the head/tail definition (`sections/foundations.tex`)

The head/tail definition in `tab:head-and-tail` absorbed all leading
applications into the **head**, so a tail could never start with an
application. This conflicted with the morphing rules `Mphi`/`Mlambda`
in `sections/operators.tex`, where `t` is the entire spine following the
redex (`Q.τ` or a λ-formation) and **may** start with an application.

Because every number and atom desugars to an application
(`5` → `Q.number(Q.bytes(⟦D> …⟧))`), reducing them requires firing `Mphi`
on the innermost redex `Q.number` with a tail `t = (Q.bytes(…))…` that
begins with an application — exactly what the old definition forbade. So
numbers and atoms were effectively un-morphable.

This change relaxes the definition so that:

- the tail is the ordered sequence of dispatches **and applications**
  attached to the head;
- a tail may begin with **either** a dispatch or an application;
- the split is **not unique** (which reconciles the table's
  head = innermost subject with the rules' head = `Q.τ`).

`tab:head-and-tail` is updated accordingly (head = innermost subject,
tail = full spine), a bare-formation row with an **empty tail** is added,
and the now-wider table is wrapped in `\adjustbox{max width=\linewidth}`
to stay within the margin.

Found while making `phino` morph/dataize by interpreting the rules
(objectionary/phino#765).

### 2. Fix `make zip` (`zip-it.sh`)

`zip-it.sh` bundled the `.sty` files from `TEXMFDIST`, but the build
resolves `eolang.sty` from `TEXMFHOME`, where it is newer and defines
`\phiTerminal`. The stale `TEXMFDIST` copy lacks it, so `make zip` failed
with `Command \phiTerminal undefined`. The script now copies each package
from the path `kpsewhich` resolves, so the arXiv zip is built from the
same `.sty` files as the normal `latexmk` build.

## Verification

- `latexmk -pdf paper` — clean build, no LaTeX errors, no overfull boxes.
- `make zip` — completes; produces the arXiv zip with the correct
  `eolang.sty`.
