### PR TITLE
feat(#16): add formal Decorator definition to foundations.tex

### DIFF
--- a/sections/foundations.tex
+++ b/sections/foundations.tex
@@ -210,6 +210,11 @@ The implementation of functions is outside the scope of \phic{}: they may be imp
   unless the decorator has its own attributes with the same names.
 \end{definition}
 
+\begin{definition}[Decorator]
+A formation is a \textbf{decorator} if it has an $@$-attribute with an expression attached to it;
+  the expression attached to the $@$-attribute is its \textbf{decoratee}.
+\end{definition}
+
 \begin{definition}[Parent]
 Attaching expression \(e\) to the $^$ attribute of formation \(b\)
   means setting the \textbf{parent} of \(b\) to \(e\).


### PR DESCRIPTION
Issue #16 asks for the decorator object to be added to the language section. The Decoration definition in `sections/foundations.tex` already mentions ``decorator'' and ``decoratee'' in parentheses, so the missing piece is a separate first-class definition that names both.

The change adds a `\begin{definition}[Decorator]` block immediately after Decoration, naming `\textbf{decorator}` and `\textbf{decoratee}` formally so the terms sit on the same footing as Atom, Parent, and Primitive in the surrounding paragraphs. No prose elsewhere needed updating since the existing references already use those words.

Local LaTeX toolchain is not available in this environment, so the build was not run locally; `latexmk` and the other checks will run on CI. The change is a five-line addition with no new macros, no new environments, and no shifted labels.

Closes #16
