### PR TITLE
#32: fail fast on curl error, refuse to build with unusable version

### DIFF
--- a/zip-it.sh
+++ b/zip-it.sh
@@ -25,7 +25,8 @@ for d in _tex sections examples; do
     cp -r "../${d}" .
 done
 
-version=$(curl --silent -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${REPO}/releases/latest" | jq -r '.tag_name')
+version=$(curl --fail --silent --show-error -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${REPO}/releases/latest" | jq -r '.tag_name')
+[ -n "${version}" ] && [ "${version}" != "null" ] || { echo "no release tag for ${REPO}" >&2; exit 1; }
 echo "Version is: ${version}"
 
 if ! sed --version; then


### PR DESCRIPTION
## What happens

In `zip-it.sh` line 28, the version of the paper is fetched from the GitHub
releases API with `curl --silent` and no failure flag:

```bash
version=$(curl --silent -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${REPO}/releases/latest" | jq -r '.tag_name')
```

When the API request fails for any reason — anonymous rate limit on a busy
network, transient 5xx, a repository that has no published releases yet
(the endpoint returns 404 with `{"message":"Not Found",...}`) — curl still
exits 0, the response body is an error JSON without a `tag_name` field, and
`jq -r '.tag_name'` substitutes the literal string `null`. The subsequent
`sed -i "s|0\.0\.0|${version}|g"` on `paper.tex` and `sections/abstract.tex`
then writes the version `null` into the paper, and the archive is named
`paper-null.zip`. The build prints `Version is: null` and otherwise
succeeds, so the corrupted artifact is uploadable to arXiv without anyone
noticing.

## What should happen

`zip-it.sh` should fail loudly instead of silently embedding an unusable
version string into the paper.

## Fix

- `curl --silent` → `curl --fail --silent --show-error` so a non-2xx
  response aborts the pipeline instead of returning an error body that
  `jq` happily extracts `null` from
- Added a guard right after the `version` assignment that exits with a
  clear error if `version` is empty or the literal string `"null"`,
  before either `sed` call touches `paper.tex` / `sections/abstract.tex`

## Verification

No test harness exists for this repo's shell scripts (no shellcheck/bashate
CI either). Verified manually:

- `bash -n zip-it.sh` — syntax valid
- Simulated all three failure paths (`version="null"`, `version=""`,
  `version="v1.2.3"`) against the new guard in isolation — the two failure
  cases exit 1 with a clear message before reaching the `sed` calls, the
  valid case proceeds unchanged

Closes #32
