### PR TITLE
#30: sort find output for deterministic example order

### DIFF
--- a/endless-to-tex.sh
+++ b/endless-to-tex.sh
@@ -13,4 +13,4 @@ while IFS= read -r f; do
         phino rewrite --normalize --focus=Q.ex "--expression=${e}" --max-depth=5 --max-cycles=1 \
             --nonumber --sequence --compress "--meet-prefix=${e}" --output=latex \
             --flat --sweet
-done < <(find "${dir}" -name '*.phi' -type f)
+done < <(find "${dir}" -name '*.phi' -type f | sort)


### PR DESCRIPTION
## What happens

In `endless-to-tex.sh` line 16 the `find` invocation is not piped through
`sort`, while the sibling `examples-to-tex.sh` line 18 already sorts:

```bash
done < <(find "${dir}" -name '*.phi' -type f)
```

`find` returns entries in filesystem order, which is not stable across
machines, filesystems, or repeated checkouts. Because
`sections/app-normalization.tex` inlines the output via
`\iexec[maybe]{./endless-to-tex.sh examples/endless > _tex/examples-endless.tex}`,
the generated `_tex/examples-endless.tex` — and therefore the appendix that
prints those endless examples — can change between rebuilds without any
source change, and the arXiv zip and the published PDF can diverge across
builds.

## What should happen

`endless-to-tex.sh` should produce the same example order on every build,
matching the deterministic behavior `examples-to-tex.sh` already has.

## Fix

One-line change: pipe `find`'s output through `sort`, matching the sibling
script's existing pattern exactly:

```diff
-done < <(find "${dir}" -name '*.phi' -type f)
+done < <(find "${dir}" -name '*.phi' -type f | sort)
```

## Verification

No test harness exists for this repo's shell scripts. Verified:

- `bash -n endless-to-tex.sh` — syntax valid
- `endless-to-tex.sh` now matches `examples-to-tex.sh`'s `find ... | sort`
  pattern exactly (confirmed via `grep` across both files)

Closes #30
