### PR TITLE
#26: fix make badge URL to point to this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Paper About φ-Calculus
 
 [![arXiv](https://img.shields.io/badge/arXiv-2111.13384-green.svg)](https://arxiv.org/abs/2111.13384)
-[![make](https://github.com/objectionary/eolang-paper/actions/workflows/latexmk.yml/badge.svg)](https://github.com/objectionary/eolang-paper/actions/workflows/latexmk.yml)
+[![make](https://github.com/objectionary/calculus-paper/actions/workflows/latexmk.yml/badge.svg)](https://github.com/objectionary/calculus-paper/actions/workflows/latexmk.yml)
 
 This is the first paper about 𝜑-calculus ([read in PDF][pdf]).
 


### PR DESCRIPTION
## What happens

The `make` badge in `README.md` line 4 references the `latexmk.yml`
workflow in `objectionary/eolang-paper`, not in this repository. Both the
image URL and the link target point to a different project, so the badge
reports the status of an unrelated workflow and clicking it leaves this
repo entirely.

## What should happen

The badge should reflect this repository's own `latexmk.yml` workflow at
`.github/workflows/latexmk.yml`.

## Fix

Replaced `objectionary/eolang-paper` with `objectionary/calculus-paper` in
both the badge image URL and the link target.

## Verification

Confirmed `.github/workflows/latexmk.yml` exists in this repo at the path
the corrected badge now points to.

Closes #26
